### PR TITLE
Fix title by adding Tasks

### DIFF
--- a/content/en/docs/08/labs/81-relabeling.md
+++ b/content/en/docs/08/labs/81-relabeling.md
@@ -1,5 +1,5 @@
 ---
-title: "8.1 Relabeling"
+title: "8.1 Tasks: Relabeling"
 weight: 81
 sectionnumber: 8.1
 ---

--- a/content/en/docs/08/labs/82-recording.md
+++ b/content/en/docs/08/labs/82-recording.md
@@ -1,5 +1,5 @@
 ---
-title: "8.2 Recording Rules"
+title: "8.2 Tasks: Recording Rules"
 weight: 82
 sectionnumber: 8.2
 ---

--- a/content/en/docs/08/labs/84-cleanup-baloise.md
+++ b/content/en/docs/08/labs/84-cleanup-baloise.md
@@ -1,5 +1,5 @@
 ---
-title: "8.4 Cleanup your monitoring workspace"
+title: "8.4 Tasks: Cleanup your monitoring workspace"
 weight: 84
 sectionnumber: 8.4
 onlyWhen: baloise


### PR DESCRIPTION
The new chapter 8 tasks were missing "Tasks" in the title.